### PR TITLE
Fixed incorrect layout tag

### DIFF
--- a/app/src/main/res/layout/activity_sample_realm.xml
+++ b/app/src/main/res/layout/activity_sample_realm.xml
@@ -10,7 +10,7 @@
     android:orientation="vertical"
     tools:context=".ExamActivity">
 
-    <com.wonshinhyo.dragrecyclerview.realm.DragRecyclerView
+    <com.wonshinhyo.dragrecyclerview.DragRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
For some reason com.wonshinhyo.dragrecyclerview.realm.DragRecyclerView is unavailable and causes the activity to crash on creation. Using com.wonshinhyo.dragrecyclerview.DragRecyclerView solved the issue.